### PR TITLE
Revert jtd-0.10

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 gem "jekyll", "~> 4.4.1" # installed by `gem jekyll`
 # gem "webrick"        # required when using Ruby >= 3 and Jekyll <= 4.2.2
 
-gem "just-the-docs", "0.10.1" # pinned to the current release
+gem "just-the-docs", "0.8.1" # pinned to the current release
 # gem "just-the-docs"        # always download the latest release
 
 gem "jekyll-katex"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,7 +52,7 @@ GEM
     jekyll-watch (2.2.1)
       listen (~> 3.0)
     json (2.12.2)
-    just-the-docs (0.10.1)
+    just-the-docs (0.8.1)
       jekyll (>= 3.8.5)
       jekyll-include-cache
       jekyll-seo-tag (>= 2.0)
@@ -69,7 +69,7 @@ GEM
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
     public_suffix (6.0.2)
-    rake (13.3.0)
+    rake (13.1.0)
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
@@ -89,7 +89,7 @@ PLATFORMS
 DEPENDENCIES
   jekyll (~> 4.4.1)
   jekyll-katex
-  just-the-docs (= 0.10.1)
+  just-the-docs (= 0.8.1)
 
 BUNDLED WITH
    2.3.26


### PR DESCRIPTION
"Merge pull request #11 from malcolmlett/dependabot/bundler/just-the-docs-0.10.1"

It caused error:
sass-embedded-1.89.2-x86_64-linux-gnu requires ruby version >= 3.2, which is incompatible with the current version, 3.1.7
Error: The process '/opt/hostedtoolcache/Ruby/3.1.7/x64/bin/bundle' failed with exit code 5

This reverts commit 2f8f2d48f4b4d14ed60a5b272c9ccf67c8f54f40, reversing changes made to 3e166b7c2b1aa21214a92d748ebaad93b62013e8.